### PR TITLE
Implement /filter toggle

### DIFF
--- a/webapp_bot/tests/test_filter.py
+++ b/webapp_bot/tests/test_filter.py
@@ -1,0 +1,14 @@
+import server_bot as sb
+
+def test_toggle_filter(monkeypatch, tmp_path):
+    db = tmp_path / "settings.json"
+    db.write_text("{}")
+    monkeypatch.setattr(sb, "SETTINGS_DB", str(db))
+
+    on = sb.toggle_filter("u1")
+    assert on is True
+    assert sb.load_json(sb.SETTINGS_DB)["u1"]["filter_off"] is True
+
+    off = sb.toggle_filter("u1")
+    assert off is False
+    assert sb.load_json(sb.SETTINGS_DB)["u1"]["filter_off"] is False

--- a/webapp_bot/user_settings.json
+++ b/webapp_bot/user_settings.json
@@ -8,6 +8,7 @@
     "speed": 1.02,
     "notifications": true,
     "dotX": 50,
-    "dotY": 50
+    "dotY": 50,
+    "filter_off": false
   }
 }


### PR DESCRIPTION
## Summary
- add toggle_filter helper and /filter command
- skip scam analysis when filter is disabled
- extend sample user_settings.json with `filter_off`
- test toggle_filter logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'TTS')*