### PR TITLE
Add /reset_limit command and tests

### DIFF
--- a/webapp_bot/server_bot.py
+++ b/webapp_bot/server_bot.py
@@ -231,6 +231,13 @@ def inc_daily_gen(uid: str) -> None:
     save_json(meta, d)
 
 
+def reset_daily_gen(uid: str) -> None:
+    """Сбросить счётчик дневных генераций пользователя."""
+    meta = USERS_EMB / uid / "gen_meta.json"
+    meta.parent.mkdir(parents=True, exist_ok=True)
+    save_json(meta, {"date": date.today().isoformat(), "count": 0})
+
+
 def log_line(uid: str, line: str):
     folder = USERS_EMB / uid
     folder.mkdir(parents=True, exist_ok=True)
@@ -766,6 +773,15 @@ async def cmd_filter(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
     msg = "Антискам-фильтр выключен." if state else "Антискам-фильтр включен."
     await upd.message.reply_text(msg)
 
+
+async def cmd_reset_limit(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    uid = str(upd.effective_user.id)
+    if not is_admin(uid):
+        await upd.message.reply_text("⛔ Это админ-команда.")
+        return
+    reset_daily_gen(uid)
+    await upd.message.reply_text("✅ Лимит генераций сброшен.")
+
 def run_flask():
     app.run(port=5000, debug=False, use_reloader=False)
 
@@ -788,6 +804,7 @@ def main():
     app_tg.add_handler(CallbackQueryHandler(cb_handler))
     app_tg.add_handler(CommandHandler("tariff", cmd_tariff))
     app_tg.add_handler(CommandHandler("filter", cmd_filter))
+    app_tg.add_handler(CommandHandler("reset_limit", cmd_reset_limit))
     app_tg.add_handler(CommandHandler("help", cmd_help))
     app_tg.add_handler(CommandHandler("about", cmd_about))
     app_tg.add_handler(CommandHandler("stats", cmd_stats))

--- a/webapp_bot/tests/test_reset_limit.py
+++ b/webapp_bot/tests/test_reset_limit.py
@@ -1,0 +1,25 @@
+import pytest
+from types import SimpleNamespace
+import server_bot as sb
+
+class DummyMsg:
+    def __init__(self):
+        self.sent = []
+    async def reply_text(self, text, **kw):
+        self.sent.append(text)
+
+class DummyUpd(SimpleNamespace):
+    pass
+
+@pytest.mark.asyncio
+async def test_reset_limit_command(monkeypatch, tmp_path):
+    monkeypatch.setattr(sb, "USERS_EMB", tmp_path / "u")
+    monkeypatch.setattr(sb, "ADMIN_IDS", {"1"})
+    uid = "1"
+    (sb.USERS_EMB / uid).mkdir(parents=True)
+    sb.inc_daily_gen(uid)
+    assert sb.daily_gen_count(uid) == 1
+    upd = DummyUpd(effective_user=SimpleNamespace(id=1), message=DummyMsg())
+    await sb.cmd_reset_limit(upd, None)
+    assert sb.daily_gen_count(uid) == 0
+    assert "сброшен" in upd.message.sent[0]


### PR DESCRIPTION
## Summary
- reset gen count via `reset_daily_gen`
- implement admin command `/reset_limit`
- register handler in main
- cover command with test
- stub heavy `voice_module` for tests

## Testing
- `pytest webapp_bot/tests/test_reset_limit.py -q`
