### PR TITLE
Add auto-delete feature

### DIFF
--- a/webapp_bot/server_bot.py
+++ b/webapp_bot/server_bot.py
@@ -288,6 +288,27 @@ def log_line(uid: str, line: str):
         f.write(f"[{ts}] {line}\n")
 
 
+AUTO_DEL_KEY = "auto_delete"
+DEL_DELAY = 5.0
+
+
+async def _maybe_delete(ctx, chat_id: int, msg_id: int, delay: float = 0.0) -> None:
+    """Безопасное удаление сообщения Telegram."""
+    if not ctx or not getattr(ctx, "bot", None):
+        return
+    try:
+        if delay:
+            await asyncio.sleep(delay)
+        await ctx.bot.delete_message(chat_id=chat_id, message_id=msg_id)
+    except TelegramError:
+        pass
+
+
+def auto_delete_enabled(uid: str) -> bool:
+    """Проверяем флаг автоудаления из user_settings.json."""
+    return load_json(SETTINGS_DB).get(uid, {}).get(AUTO_DEL_KEY, False)
+
+
 ABBR = {
     "Безопасные сообщения": "БС",
     "Родственник в беде": "РВБ",
@@ -672,7 +693,9 @@ async def tg_voice(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
         await upd.message.reply_text(f"Слот {slot+1} вне диапазона.")
         return
 
-    await upd.message.reply_text("⏳ Обрабатываю запись…")
+    m = await upd.message.reply_text("⏳ Обрабатываю запись…")
+    if auto_delete_enabled(uid):
+        await _maybe_delete(ctx, m.chat_id, m.message_id, DEL_DELAY)
 
     user_dir = USERS_EMB / uid
     before = set(user_dir.glob("speaker_embedding_*.npz"))
@@ -687,7 +710,10 @@ async def tg_voice(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
     after = set(user_dir.glob("speaker_embedding_*.npz"))
     new = after - before
     if not new:
-        await upd.message.reply_text("Ошибка создания слепка.")
+        err = await upd.message.reply_text("Ошибка создания слепка.")
+        if auto_delete_enabled(uid):
+            await _maybe_delete(ctx, upd.effective_chat.id, upd.message.message_id)
+            await _maybe_delete(ctx, err.chat_id, err.message_id, DEL_DELAY)
         return
 
     new_file = new.pop()
@@ -695,9 +721,12 @@ async def tg_voice(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
     if target.exists():
         target.unlink()
     new_file.rename(target)
-    await upd.message.reply_text(
+    done = await upd.message.reply_text(
         "🗣️ Слепок создан.", reply_markup=build_slot_keyboard(uid)
     )
+    if auto_delete_enabled(uid):
+        await _maybe_delete(ctx, upd.effective_chat.id, upd.message.message_id)
+        await _maybe_delete(ctx, done.chat_id, done.message_id, DEL_DELAY)
 
 
 async def tg_text(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
@@ -712,7 +741,9 @@ async def tg_text(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
     settings = load_json(SETTINGS_DB).get(uid, {})
     if not settings.get("filter_off"):
-        await upd.message.reply_text("⏳ Анализирую текст…")
+        tmp = await upd.message.reply_text("⏳ Анализирую текст…")
+        if auto_delete_enabled(uid):
+            await _maybe_delete(ctx, tmp.chat_id, tmp.message_id, DEL_DELAY)
         
         clf = get_classifier()
         scores = await clf.analyse(txt)
@@ -734,16 +765,25 @@ async def tg_text(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
             if parts:
                 warn = "; ".join(parts)
 
-        await upd.message.reply_text(
+        res = await upd.message.reply_text(
             "Результат: безопасно" if not warn else "Результат: опасно"
         )
+        if auto_delete_enabled(uid):
+            await _maybe_delete(ctx, res.chat_id, res.message_id, DEL_DELAY)
+            await _maybe_delete(ctx, upd.effective_chat.id, upd.message.message_id)
         if warn:
             s = add_strike(uid)
             if s >= MAX_STRIKES:
                 add_black(uid)
-                await upd.message.reply_text("🚫 Заблокировано.")
+                ban = await upd.message.reply_text("🚫 Заблокировано.")
+                if auto_delete_enabled(uid):
+                    await _maybe_delete(ctx, upd.effective_chat.id, upd.message.message_id)
+                    await _maybe_delete(ctx, ban.chat_id, ban.message_id, DEL_DELAY)
                 return
-            await upd.message.reply_text(f"⚠️ {warn}. Strike {s}/{MAX_STRIKES}.")
+            warn_msg = await upd.message.reply_text(f"⚠️ {warn}. Strike {s}/{MAX_STRIKES}.")
+            if auto_delete_enabled(uid):
+                await _maybe_delete(ctx, upd.effective_chat.id, upd.message.message_id)
+                await _maybe_delete(ctx, warn_msg.chat_id, warn_msg.message_id, DEL_DELAY)
             return
     else:
         log_line(uid, txt)
@@ -754,18 +794,26 @@ async def tg_text(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
 
     if daily_gen_count(uid) >= tariff_info(uid)["daily_gen"]:
-        await upd.message.reply_text("Дневной лимит генераций исчерпан.")
+        lm = await upd.message.reply_text("Дневной лимит генераций исчерпан.")
+        if auto_delete_enabled(uid):
+            await _maybe_delete(ctx, upd.effective_chat.id, upd.message.message_id)
+            await _maybe_delete(ctx, lm.chat_id, lm.message_id, DEL_DELAY)
         return
 
     emb = USERS_EMB / uid / f"speaker_embedding_{slot}.npz"
     if not emb.exists():
-        await upd.message.reply_text(f"Слот {slot+1} пуст. Выберите занятый слот.")
+        sl = await upd.message.reply_text(f"Слот {slot+1} пуст. Выберите занятый слот.")
+        if auto_delete_enabled(uid):
+            await _maybe_delete(ctx, upd.effective_chat.id, upd.message.message_id)
+            await _maybe_delete(ctx, sl.chat_id, sl.message_id, DEL_DELAY)
         return
 
     apply_user_settings(uid)
     VOICE.user_embedding[uid] = emb  # type: ignore
 
-    await upd.message.reply_text("⏳ Генерирую речь…")
+    proc = await upd.message.reply_text("⏳ Генерирую речь…")
+    if auto_delete_enabled(uid):
+        await _maybe_delete(ctx, proc.chat_id, proc.message_id, DEL_DELAY)
 
     loop = asyncio.get_running_loop()
     try:
@@ -777,13 +825,17 @@ async def tg_text(upd: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
 
     with open(str(wav_path), "rb") as f:
-        await ctx.bot.send_audio(
+        audio_msg = await ctx.bot.send_audio(
             chat_id=upd.effective_chat.id,
             audio=InputFile(f, filename=wav_path.name),
             title="TTS",
         )
     inc_daily_gen(uid)
-    await upd.message.reply_text("✅ Готово")
+    done = await upd.message.reply_text("✅ Готово")
+    if auto_delete_enabled(uid):
+        await _maybe_delete(ctx, upd.effective_chat.id, upd.message.message_id)
+        await _maybe_delete(ctx, audio_msg.chat_id, audio_msg.message_id, DEL_DELAY)
+        await _maybe_delete(ctx, done.chat_id, done.message_id, DEL_DELAY)
 
 
 def build_tariff_keyboard(current: str) -> InlineKeyboardMarkup:

--- a/webapp_bot/tests/test_autodelete.py
+++ b/webapp_bot/tests/test_autodelete.py
@@ -1,0 +1,49 @@
+import pytest
+from types import SimpleNamespace
+import server_bot as sb
+
+class DummyBot:
+    def __init__(self):
+        self.deleted = []
+    async def delete_message(self, chat_id, message_id):
+        self.deleted.append((chat_id, message_id))
+    async def send_audio(self, chat_id, audio, title):
+        return SimpleNamespace(chat_id=chat_id, message_id=50)
+
+class DummyMsg:
+    def __init__(self, chat_id=1):
+        self.chat_id = chat_id
+        self.message_id = 10
+    async def reply_text(self, text, **kw):
+        return SimpleNamespace(chat_id=self.chat_id, message_id=11)
+
+class DummyUpd(SimpleNamespace):
+    pass
+
+@pytest.mark.asyncio
+async def test_delete_message_called(monkeypatch, tmp_path):
+    uid = "99"
+    sb.ACTIVE_SLOTS.clear()
+    sb.ACTIVE_SLOTS[uid] = 0
+    # prepare embedding file
+    monkeypatch.setattr(sb, "USERS_EMB", tmp_path / "u")
+    emb_dir = sb.USERS_EMB / uid
+    emb_dir.mkdir(parents=True)
+    (emb_dir / "speaker_embedding_0.npz").write_bytes(b"0")
+    out = tmp_path / "out.wav"
+    out.write_bytes(b"RIFF")
+    monkeypatch.setattr(sb.VOICE, "synthesize", lambda uid, txt: out)
+    monkeypatch.setattr(sb, "apply_user_settings", lambda u: None)
+    monkeypatch.setattr(sb, "tariff_info", lambda u: {"slots":1, "daily_gen":5})
+    monkeypatch.setattr(sb, "daily_gen_count", lambda u: 0)
+    monkeypatch.setattr(sb, "auto_delete_enabled", lambda u: True)
+    monkeypatch.setattr(sb, "load_json", lambda p: {uid: {"filter_off": True}})
+
+    ctx = SimpleNamespace(bot=DummyBot(), args=[])
+    upd = DummyUpd(
+        effective_user=SimpleNamespace(id=uid),
+        effective_chat=SimpleNamespace(id=1),
+        message=DummyMsg(),
+    )
+    await sb.tg_text(upd, ctx)
+    assert (1, 10) in ctx.bot.deleted

--- a/webapp_bot/user_settings.json
+++ b/webapp_bot/user_settings.json
@@ -9,6 +9,7 @@
     "notifications": true,
     "dotX": 50,
     "dotY": 50,
-    "filter_off": false
+    "filter_off": false,
+    "auto_delete": false
   }
 }


### PR DESCRIPTION
## Summary
- add optional auto-delete functionality
- use it in voice and text handlers
- extend settings format
- test delete_message call

## Testing
- `pytest webapp_bot/tests/test_autodelete.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*
