### PR TITLE
Handle video input for voice embedding

### DIFF
--- a/webapp_bot/tests/conftest.py
+++ b/webapp_bot/tests/conftest.py
@@ -28,6 +28,13 @@ class DummyVM:
 
 sys.modules['voice_module'] = types.ModuleType('voice_module')
 sys.modules['voice_module'].VoiceModule = DummyVM
+sys.modules['audio_checker'] = types.ModuleType('audio_checker')
+sys.modules['audio_checker'].predict = lambda path: "BINARY:0 CLASS:0"
+sys.modules['classifier'] = types.ModuleType('classifier')
+class DummyClf:
+    async def analyse(self, text):
+        return {"Безопасные сообщения": 1.0}
+sys.modules['classifier'].get_classifier = lambda: DummyClf()
 
 from server_bot import app as flask_app, VOICE
 
@@ -40,7 +47,7 @@ def client():
 def silence_wav(tmp_path):
     """1-секундный WAV 16 kHz silence."""
     path = tmp_path / "silence.wav"
-    with contextlib.closing(wave.open(path, "w")) as f:
+    with contextlib.closing(wave.open(str(path), "w")) as f:
         f.setnchannels(1); f.setsampwidth(2); f.setframerate(16_000)
         f.writeframes(b"\x00\x00" * 16_000)
     return path

--- a/webapp_bot/tests/test_video_input.py
+++ b/webapp_bot/tests/test_video_input.py
@@ -1,0 +1,59 @@
+import pytest
+from types import SimpleNamespace
+import server_bot as sb
+
+class DummyBot:
+    async def get_file(self, file_id):
+        class F:
+            async def download_to_drive(self, dest):
+                open(dest, "wb").write(b"vid")
+        return F()
+
+class DummyMsg:
+    def __init__(self):
+        self.voice = None
+        self.audio = None
+        self.video = SimpleNamespace(file_id="v1")
+        self.video_note = None
+        self.sent = []
+    async def reply_text(self, text, **kw):
+        self.sent.append(text)
+        return SimpleNamespace(chat_id=1, message_id=1)
+
+@pytest.mark.asyncio
+async def test_video_to_wav(monkeypatch, tmp_path):
+    uid = "55"
+    monkeypatch.setattr(sb, "USERS_EMB", tmp_path / "u")
+    (sb.USERS_EMB / uid).mkdir(parents=True)
+    sb.ACTIVE_SLOTS[uid] = 0
+    monkeypatch.setattr(sb, "tariff_info", lambda u: {"slots": 1})
+    monkeypatch.setattr(sb, "auto_delete_enabled", lambda u: False)
+
+    called = {}
+    def fake_create(path, user):
+        called["path"] = path
+        open(path, "wb").write(b"RIFF")
+        return path
+    monkeypatch.setattr(sb.VOICE, "create_embedding", fake_create)
+
+    used = {}
+    def fake_from_file(src):
+        used["src"] = src
+        class S:
+            def set_channels(self, *a): return self
+            def set_frame_rate(self, *a): return self
+            def set_sample_width(self, *a): return self
+            def export(self, dst, format):
+                open(dst, 'wb').write(b'RIFF')
+                return dst
+        return S()
+    monkeypatch.setattr(sb, "AudioSegment", SimpleNamespace(from_file=fake_from_file))
+
+    ctx = SimpleNamespace(bot=DummyBot())
+    msg = DummyMsg()
+    upd = SimpleNamespace(effective_user=SimpleNamespace(id=uid),
+                          effective_message=msg,
+                          message=msg)
+    await sb.tg_voice(upd, ctx)
+    assert "src" in used
+    assert called["path"].endswith(".wav")


### PR DESCRIPTION
## Summary
- support `upd.message.video` и `upd.message.video_note` в обработчике `tg_voice`
- конвертация видео в WAV при помощи `pydub.AudioSegment.from_file`
- обновить заглушки в тестах и добавить `test_video_input`

## Testing
- `pytest webapp_bot/tests/test_video_input.py::test_video_to_wav -q`